### PR TITLE
Remove huge switch statement and add Applier() interface instead.

### DIFF
--- a/frequent_flier_account.go
+++ b/frequent_flier_account.go
@@ -46,26 +46,18 @@ func (state *FrequentFlierAccount) trackChange(event interface{}) {
 	state.transition(event)
 }
 
+type Applier interface  {
+    Apply(state *FrequentFlierAccount)
+}
+
 // transition imnplements the pattern match against event types used both as part
 // of the fold when loading from history and when tracking an individual change.
 func (state *FrequentFlierAccount) transition(event interface{}) {
 	switch e := event.(type) {
-
-	case FrequentFlierAccountCreated:
-		state.id = e.AccountId
-		state.miles = e.OpeningMiles
-		state.tierPoints = e.OpeningTierPoints
-		state.status = StatusRed
-
-	case StatusMatched:
-		state.status = e.NewStatus
-
-	case FlightTaken:
-		state.miles = state.miles + e.MilesAdded
-		state.tierPoints = state.tierPoints + e.TierPointsAdded
-
-	case PromotedToGoldStatus:
-		state.status = StatusGold
+    case Applier:
+        e.Apply(state)
+    default:
+        panic("UNKNOWN EVENT!")
 	}
 }
 

--- a/frequent_flier_events.go
+++ b/frequent_flier_events.go
@@ -17,8 +17,19 @@ type FrequentFlierAccountCreated struct {
 	OpeningTierPoints int
 }
 
+func (e FrequentFlierAccountCreated) Apply(state *FrequentFlierAccount) {
+    state.id = e.AccountId
+    state.miles = e.OpeningMiles
+    state.tierPoints = e.OpeningTierPoints
+    state.status = StatusRed
+}
+
 type StatusMatched struct {
 	NewStatus Status
+}
+
+func (e StatusMatched) Apply(state *FrequentFlierAccount) {
+    state.status = e.NewStatus
 }
 
 type FlightTaken struct {
@@ -26,4 +37,13 @@ type FlightTaken struct {
 	TierPointsAdded int
 }
 
+func (e FlightTaken) Apply(state *FrequentFlierAccount) {
+    state.miles = state.miles + e.MilesAdded
+    state.tierPoints = state.tierPoints + e.TierPointsAdded
+}
+
 type PromotedToGoldStatus struct{}
+
+func (e PromotedToGoldStatus) Apply(state *FrequentFlierAccount) {
+    state.status = StatusGold
+}


### PR DESCRIPTION
Make it easier to add future extensibility by removing the big case statement in favor of an Applier() interface.

Signed-off-by: Michael Brown <mebrown@michaels-house.net>